### PR TITLE
refactor: modify the yml file with minor changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - postgres
             - redis
         networks:
-            - recipies-network
+            - recipes-network
 
     postgres:
         image: postgres:15
@@ -34,7 +34,7 @@ services:
             - 'postgres-db:/var/lib/postgresql/data'
             - './tests/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql' # https://stackoverflow.com/questions/26598738/how-to-create-user-database-in-script-for-docker-postgres
         networks:
-            - recipies-network
+            - recipes-network
         healthcheck:
             test: [ "CMD", "pg_isready", "-q", "-d", "${POSTGRES_DB}", "-U", "${POSTGRES_USER}" ]
             retries: 3
@@ -45,7 +45,7 @@ services:
         image: dpage/pgadmin4
         container_name: 'recipes-api.pgadmin'
         restart: always
-        environment: # IMPORTANT! Use <host.docker.internal> as the host name when creating the server in pgadmin
+        environment: # IMPORTANT! Use postgres container name as the host name when creating the server in pgadmin
             PGADMIN_DEFAULT_EMAIL: '${PG_ADMIN_EMAIL:-admin@admin.com}'
             PGADMIN_DEFAULT_PASSWORD: '${PG_ADMIN_PASSWORD:-root}'
         ports:
@@ -53,7 +53,7 @@ services:
         depends_on:
             - postgres
         networks:
-            - recipies-network
+            - recipes-network
         volumes:
             -   'pg-admin:/var/lib/pgadmin'
 
@@ -65,14 +65,14 @@ services:
         volumes:
             - 'redis-cache:/data'
         networks:
-            - recipies-network
+            - recipes-network
         healthcheck:
             test: [ "CMD", "redis-cli", "ping" ]
             retries: 3
             timeout: 5s
 
 networks: # https://www.simplilearn.com/tutorials/docker-tutorial/docker-networking#:~:text=Docker%20networking%20enables%20a%20user,to%20more%20than%20one%20network.
-    recipies-network:
+    recipes-network:
         driver: bridge
 
 volumes:


### PR DESCRIPTION
## Description

- Corrects grammatical error: `recipies-network` to `recipes-network`.
- Adds container name for `postgres` service.

## Reason for change

- Container name for postgres allows access to the db from pgadmin.

## Checklist

- [ ] I have added/updated tests for this change (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] This PR doesn't contain any unrelated changes.

## References

- https://www.pintonista.com/connecting-pgadmin-to-postgres-container/