### PR TITLE
chore: add dependencies for formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 100
+exclude = .git,__pycache__,.venv, __init__.py,.mypy_cache,.pytest_cache
+
+[pep8]
+ignore = E203, W503

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY pyproject.toml poetry.lock /api/
 RUN poetry config virtualenvs.create false
 RUN poetry install --no-root --no-interaction
 
-CMD ["uvicorn", "routes:app", "--host", "0.0.0.0", "--port", "4002"]
+CMD ["uvicorn", "app.routes:app", "--host", "0.0.0.0", "--port", "4002"]

--- a/app/config.py
+++ b/app/config.py
@@ -1,42 +1,51 @@
-from pydantic import BaseSettings
-from dotenv import load_dotenv
 import os
+from typing import Optional
+
+from dotenv import load_dotenv
+from pydantic import BaseSettings
 
 load_dotenv()
+
 
 class BaseConfig(BaseSettings):
     app_name: str = "My App"
     debug: bool = False
     testing: bool = False
 
-    POSTGRES_PORT: int = os.getenv("POSTGRES_PORT")
-    POSTGRES_PASSWORD: str = os.getenv("POSTGRES_PASSWORD")
-    POSTGRES_USER: str = os.getenv("POSTGRES_USER")
-    POSTGRES_DB: str = os.getenv("POSTGRES_DB")
-    POSTGRES_HOST: str = os.getenv("POSTGRES_HOST")
-    POSTGRES_HOSTNAME: str = os.getenv("POSTGRES_HOSTNAME")
+    POSTGRES_PORT: Optional[str] = os.getenv("POSTGRES_PORT")
+    POSTGRES_PASSWORD: Optional[str] = os.getenv("POSTGRES_PASSWORD")
+    POSTGRES_USER: Optional[str] = os.getenv("POSTGRES_USER")
+    POSTGRES_DB: Optional[str] = os.getenv("POSTGRES_DB")
+    POSTGRES_HOST: Optional[str] = os.getenv("POSTGRES_HOST")
+    POSTGRES_HOSTNAME: Optional[str] = os.getenv("POSTGRES_HOSTNAME")
+
 
 class DevelopmentConfig(BaseConfig):
     debug: bool = True
 
+
 class TestingConfig(BaseConfig):
     testing: bool = True
 
+
 class ProductionConfig(BaseConfig):
-    POSTGRES_PORT: int = os.getenv("PROD_POSTGRES_PORT")
-    POSTGRES_PASSWORD: str = os.getenv("PROD_POSTGRES_PASSWORD")
-    POSTGRES_USER: str = os.getenv("PROD_POSTGRES_USER")
-    POSTGRES_DB: str = os.getenv("PROD_POSTGRES_DB")
-    POSTGRES_HOST: str = os.getenv("PROD_POSTGRES_HOST")
-    POSTGRES_HOSTNAME: str = os.getenv("PROD_POSTGRES_HOSTNAME")
+    POSTGRES_PORT: Optional[str] = os.getenv("PROD_POSTGRES_PORT")
+    POSTGRES_PASSWORD: Optional[str] = os.getenv("PROD_POSTGRES_PASSWORD")
+    POSTGRES_USER: Optional[str] = os.getenv("PROD_POSTGRES_USER")
+    POSTGRES_DB: Optional[str] = os.getenv("PROD_POSTGRES_DB")
+    POSTGRES_HOST: Optional[str] = os.getenv("PROD_POSTGRES_HOST")
+    POSTGRES_HOSTNAME: Optional[str] = os.getenv("PROD_POSTGRES_HOSTNAME")
+
 
 # Use the appropriate configuration class based on the current environment
 
-env: str = os.getenv('ENV')
+env: Optional[str] = os.getenv("ENV")
 
-if env == "production" or env == 'prod':
-    settings = ProductionConfig()
-elif env == "testing":
-    settings = TestingConfig()
-else:
-    settings = DevelopmentConfig()
+if env == "production" or env == "prod":
+    settings: ProductionConfig = ProductionConfig()
+
+if env == "testing":
+    settings: TestingConfig = TestingConfig()  # type: ignore [no-redef]
+
+if env != "testing" or env == "production" or env == "prod":
+    settings: DevelopmentConfig = DevelopmentConfig()  # type: ignore [no-redef]

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,5 +1,6 @@
 from enum import Enum as PyEnum
 
+
 class Role(PyEnum):
     USER = "user"
     ADMIN = "admin"

--- a/app/db/base_class.py
+++ b/app/db/base_class.py
@@ -1,25 +1,29 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy import DateTime, String
-
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
 def get_current_datetime() -> datetime:
     return datetime.now()
 
+
 def generate_uuid() -> str:
     return str(uuid.uuid4())
 
+
 def generate_fake_email() -> str:
     return f"{uuid.uuid4()}@fake.african.recipes"
+
 
 class Base(DeclarativeBase):
     __abstract__ = True
     __allow_unmapped__ = True
 
-    id : Mapped[uuid.UUID] = mapped_column(String, primary_key=True, default=generate_uuid)
+    id: Mapped[uuid.UUID] = mapped_column(
+        String, primary_key=True, default=generate_uuid
+    )
     created_at = mapped_column(DateTime, default=get_current_datetime, nullable=False)
     updated_at = mapped_column(
         DateTime, default=None, onupdate=get_current_datetime, nullable=True

--- a/app/db/db.py
+++ b/app/db/db.py
@@ -1,13 +1,16 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from config import settings
 
-DATABASE_URL = f"postgresql://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{settings.POSTGRES_DB}"
-engine=create_engine(DATABASE_URL, future=True, echo=True)
-SessionLocal=sessionmaker(autocommit=False, autoflush=False,bind=engine)
+from app.config import settings
 
-def get_db() -> None:
-    db=SessionLocal()
+DATABASE_URL = f"postgresql://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}@"
+f"{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{settings.POSTGRES_DB}"
+engine = create_engine(DATABASE_URL, future=True, echo=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db() -> None:  # type: ignore [misc]
+    db = SessionLocal()
     try:
         yield db
     finally:

--- a/app/models.py
+++ b/app/models.py
@@ -1,10 +1,11 @@
-from typing import List
 import uuid
-from constants import Role
-from sqlalchemy.orm import relationship, Mapped, mapped_column
-from sqlalchemy import Integer, String, ForeignKey, Float, Text, TIMESTAMP, text, Column, UUID
-from db.base_class import Base, generate_fake_email
+from typing import List
 
+from sqlalchemy import Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.constants import Role
+from app.db.base_class import Base, generate_fake_email
 
 
 class User(Base):
@@ -13,9 +14,13 @@ class User(Base):
     first_name: Mapped[str] = mapped_column(String, nullable=False)
     last_name: Mapped[str] = mapped_column(String, nullable=False)
     username: Mapped[str] = mapped_column(String, unique=True)
-    email = mapped_column(String, unique=True, index=True, default=generate_fake_email, nullable=True)
+    email = mapped_column(
+        String, unique=True, index=True, default=generate_fake_email, nullable=True
+    )
     password_hash = mapped_column(String, nullable=False)
-    role = mapped_column(String, nullable=False, default=Role.USER.value,server_default=Role.USER.value)
+    role = mapped_column(
+        String, nullable=False, default=Role.USER.value, server_default=Role.USER.value
+    )
     recipes: Mapped[List["Recipe"]] = relationship(back_populates="user")
     comments: Mapped[List["Comment"]] = relationship(back_populates="user")
     rating: Mapped[List["Rating"]] = relationship(back_populates="user")
@@ -34,13 +39,19 @@ class Recipe(Base):
     servings: Mapped[int] = mapped_column(Integer)
     image_url: Mapped[str] = mapped_column(String, nullable=False)
 
-    user_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("user.id"), nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        String, ForeignKey("user.id"), nullable=False
+    )
     user: Mapped["User"] = relationship("User", back_populates="recipes")
     tags: Mapped[List["RecipeTags"]] = relationship(back_populates="recipes")
-    ingredients: Mapped[List["RecipeIngredients"]] = relationship(back_populates="recipes")
+    ingredients: Mapped[List["RecipeIngredients"]] = relationship(
+        back_populates="recipes"
+    )
     comments: Mapped[List["Comment"]] = relationship(back_populates="recipe")
     rating: Mapped["Rating"] = relationship(back_populates="recipe")
-    nutritional_info = relationship("NutritionalInfo", uselist=False, back_populates="recipe")
+    nutritional_info = relationship(
+        "NutritionalInfo", uselist=False, back_populates="recipe"
+    )
 
 
 class Tag(Base):
@@ -53,8 +64,12 @@ class Tag(Base):
 class RecipeTags(Base):
     __tablename__ = "recipe_tags"
 
-    recipe_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("recipes.id"), primary_key=True)
-    tag_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("tags.id"), primary_key=True)
+    recipe_id: Mapped[uuid.UUID] = mapped_column(
+        String, ForeignKey("recipes.id"), primary_key=True
+    )
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        String, ForeignKey("tags.id"), primary_key=True
+    )
 
     tags: Mapped["Tag"] = relationship(back_populates="recipes")
     recipes: Mapped["Recipe"] = relationship(back_populates="tags")
@@ -72,8 +87,12 @@ class Ingredients(Base):
 class RecipeIngredients(Base):
     __tablename__ = "recipe_ingredients"
 
-    recipe_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("recipes.id"), primary_key=True)
-    ingredient_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("ingredients.id"), primary_key=True)
+    recipe_id: Mapped[uuid.UUID] = mapped_column(
+        String, ForeignKey("recipes.id"), primary_key=True
+    )
+    ingredient_id: Mapped[uuid.UUID] = mapped_column(
+        String, ForeignKey("ingredients.id"), primary_key=True
+    )
     quantity: Mapped[int] = mapped_column(Integer)
 
     ingredients: Mapped["Ingredients"] = relationship(back_populates="recipes")
@@ -84,16 +103,22 @@ class Comment(Base):
     __tablename__ = "comments"
 
     comment: Mapped[str] = mapped_column(String, nullable=True)
-    recipe_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("recipes.id"), nullable=False)
+    recipe_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("recipes.id"), nullable=False
+    )
     recipe: Mapped["Recipe"] = relationship(back_populates="comments")
-    user_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("user.id"), nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        String, ForeignKey("user.id"), nullable=False
+    )
     user: Mapped["User"] = relationship(back_populates="comments")
 
 
 class Rating(Base):
     __tablename__ = "ratings"
 
-    recipe_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("recipes.id"), nullable=False)
+    recipe_id: Mapped[uuid.UUID] = mapped_column(
+        String, ForeignKey("recipes.id"), nullable=False
+    )
     recipe: Mapped["Recipe"] = relationship(back_populates="rating")
     user_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("user.id"))
     user: Mapped["User"] = relationship(back_populates="rating")
@@ -110,7 +135,9 @@ class NutritionalInfo(Base):
     sugar: Mapped[float] = mapped_column(Float)
     sodium: Mapped[float] = mapped_column(Float)
 
-    recipe_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("recipes.id"), nullable=False)
+    recipe_id: Mapped[uuid.UUID] = mapped_column(
+        String, ForeignKey("recipes.id"), nullable=False
+    )
     recipe = relationship("Recipe", back_populates="nutritional_info")
 
 
@@ -118,6 +145,7 @@ class Image(Base):
     __tablename__ = "images"
 
     url: Mapped[str] = mapped_column(String, nullable=False)
-    user_id: Mapped[uuid.UUID] = mapped_column(String, ForeignKey("user.id"), nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        String, ForeignKey("user.id"), nullable=False
+    )
     user: Mapped["User"] = relationship(back_populates="image")
-    

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,37 +1,39 @@
-from fastapi import FastAPI, Depends
-from db.db import get_db
-from models import Recipe
-from utils import create_recipe, get_recipe, get_recipes, delete_recipe
-from schemas import RecipeSerializer, RecipeCreateSerializer
-from typing import List, Any, Dict
+from typing import Any, Dict, List
+
+from fastapi import Depends, FastAPI
 from sqlalchemy.orm import Session
 
-app=FastAPI()
+from app.db.db import get_db
+from app.schemas import RecipeCreateSerializer, RecipeSerializer
+from app.utils import create_recipe, get_recipe, get_recipes, remove_recipe
 
-@app.post('/recipes', response_model=RecipeSerializer)
+app = FastAPI()
+
+
+@app.post("/recipes", response_model=RecipeSerializer)
 def create_recipes(
     recipe: RecipeCreateSerializer,
-    db: Session=Depends(get_db),
+    db: Session = Depends(get_db),
 ) -> Any:
-    db_obj=create_recipe(db,recipe)
+    db_obj = create_recipe(db, recipe)
     return db_obj
 
-@app.get('/recipes', response_model=List[RecipeSerializer])
+
+@app.get("/recipes", response_model=List[RecipeSerializer])
 def read_recipes(
     db: Session = Depends(get_db),
 ) -> Any:
     return get_recipes(db)
 
-@app.get('/recipe/{recipe_id}', response_model=RecipeSerializer)
+
+@app.get("/recipe/{recipe_id}", response_model=RecipeSerializer)
 def read_recipe(
     recipe_id: int,
     db: Session = Depends(get_db),
 ) -> Any:
     return get_recipe(db, recipe_id)
 
-@app.delete('/recipe/{recipe_id}')
-def delete_recipe(
-    recipe_id: int,
-    db: Session = Depends(get_db)
-) -> Dict:
-    return delete_recipe(db, recipe_id)
+
+@app.delete("/recipe/{recipe_id}")
+def delete_recipe(recipe_id: int, db: Session = Depends(get_db)) -> Dict:
+    return remove_recipe(db, recipe_id)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,21 +1,24 @@
-from pydantic import BaseModel
 from typing import List
+
+from pydantic import BaseModel
+
 
 class RecipeCreateSerializer(BaseModel):
     id: str
-    serving:int
-    ingredients:List[str]
-    instructions:str
+    serving: int
+    ingredients: List[str]
+    instructions: str
 
     class Config:
-        orm_mode=True
+        orm_mode = True
+
+
 class RecipeSerializer(BaseModel):
     title: str
-    serving:int
-    ingredients:List[str]
-    instructions:str
+    serving: int
+    ingredients: List[str]
+    instructions: str
 
-    #allows pydantic to create orm objects from pydantic objects
+    # allows pydantic to create orm objects from pydantic objects
     class Config:
-        orm_mode=True
-        
+        orm_mode = True

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,8 +1,10 @@
 from sqlalchemy.orm import Session
-from schemas import RecipeCreateSerializer
-from models import Recipe
 
-def create_recipe(db: Session,recipe: RecipeCreateSerializer):
+from app.models import Recipe
+from app.schemas import RecipeCreateSerializer
+
+
+def create_recipe(db: Session, recipe: RecipeCreateSerializer):
     db_obj = Recipe(**recipe.dict())
     db.add(db_obj)
     db.commit()
@@ -10,16 +12,19 @@ def create_recipe(db: Session,recipe: RecipeCreateSerializer):
 
     return db_obj
 
-def get_recipe(db: Session, recipe_id:int):
-    recipe = db.query(Recipe).where(Recipe.id==recipe_id).first()
+
+def get_recipe(db: Session, recipe_id: int):
+    recipe = db.query(Recipe).where(Recipe.id == recipe_id).first()
     return recipe
+
 
 def get_recipes(db: Session):
     recipes = db.query(Recipe).all()
     return recipes
 
-def delete_recipe(db: Session, recipe_id:int):
-    db_obj=db.query(Recipe).where(Recipe.id==recipe_id).first()
+
+def remove_recipe(db: Session, recipe_id: int):
+    db_obj = db.query(Recipe).where(Recipe.id == recipe_id).first()
     db.delete(db_obj)
     db.commit()
-    return {'message':'Recipe deleted'}
+    return {"message": "Recipe deleted"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
         build: .
         container_name: 'recipes-api'
         volumes:
-            - .:/api
+            - .:/api/app
         ports:
             - 4002:4002
         env_file: # https://stackoverflow.com/questions/58047984/why-do-i-need-to-declare-env-file-explicitely-in-docker-compose-yml

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,6 +32,40 @@ test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (>=0.16,<0.22)"]
 
 [[package]]
+name = "autoflake"
+version = "2.1.1"
+description = "Removes unused imports and unused variables"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pyflakes = ">=3.0.0"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[[package]]
+name = "black"
+version = "23.3.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -51,6 +85,17 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 
 [[package]]
+name = "exceptiongroup"
+version = "1.1.1"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "fastapi"
 version = "0.92.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -67,6 +112,19 @@ all = ["email-validator (>=1.1.1)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)"
 dev = ["pre-commit (>=2.17.0,<3.0.0)", "ruff (==0.0.138)", "uvicorn[standard] (>=0.12.0,<0.21.0)"]
 doc = ["mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.3.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pyyaml (>=5.3.1,<7.0.0)", "typer[all] (>=0.6.1,<0.8.0)"]
 test = ["anyio[trio] (>=3.2.1,<4.0.0)", "black (==22.10.0)", "coverage[toml] (>=6.5.0,<8.0)", "databases[sqlite] (>=0.3.2,<0.7.0)", "email-validator (>=1.1.1,<2.0.0)", "flask (>=1.1.2,<3.0.0)", "httpx (>=0.23.0,<0.24.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.982)", "orjson (>=3.2.1,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "peewee (>=3.13.3,<4.0.0)", "pytest (>=7.1.3,<8.0.0)", "python-jose[cryptography] (>=3.3.0,<4.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "pyyaml (>=5.3.1,<7.0.0)", "ruff (==0.0.138)", "sqlalchemy (>=1.3.18,<1.4.43)", "types-orjson (==3.6.2)", "types-ujson (==5.6.0.0)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0,<6.0.0)"]
+
+[[package]]
+name = "flake8"
+version = "6.0.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.8.1"
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.10.0,<2.11.0"
+pyflakes = ">=3.0.0,<3.1.0"
 
 [[package]]
 name = "greenlet"
@@ -97,6 +155,28 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "isort"
+version = "5.12.0"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.8.0"
+
+[package.extras]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
+
+[[package]]
 name = "Mako"
 version = "1.2.4"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
@@ -121,10 +201,93 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "mypy"
+version = "1.3.0"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "packaging"
+version = "23.1"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "pathspec"
+version = "0.11.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "platformdirs"
+version = "3.5.1"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "psycopg2"
 version = "2.9.6"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
 category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pycodestyle"
+version = "2.10.0"
+description = "Python style guide checker"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -142,6 +305,33 @@ typing-extensions = ">=4.2.0"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
+
+[[package]]
+name = "pyflakes"
+version = "3.0.1"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pytest"
+version = "7.3.1"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "python-dotenv"
@@ -212,6 +402,14 @@ anyio = ">=3.4.0,<5"
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -237,7 +435,7 @@ standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)",
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "9c38f11fa6b4d06f4bafb740096ed0ed0434f0886e0f25bd920d64e8a1cbcd0b"
+content-hash = "ad9fdaea2f768c4a0d2b3f52ba53bbb36b91ccf952cb14d9a350d947efed7c4c"
 
 [metadata.files]
 alembic = [
@@ -248,6 +446,37 @@ anyio = [
     {file = "anyio-3.6.2-py3-none-any.whl", hash = "sha256:fbbe32bd270d2a2ef3ed1c5d45041250284e31fc0a4df4a5a6071842051a51e3"},
     {file = "anyio-3.6.2.tar.gz", hash = "sha256:25ea0d673ae30af41a0c442f81cf3b38c7e79fdc7b60335a4c14e05eb0947421"},
 ]
+autoflake = [
+    {file = "autoflake-2.1.1-py3-none-any.whl", hash = "sha256:94e330a2bcf5ac01384fb2bf98bea60c6383eaa59ea62be486e376622deba985"},
+    {file = "autoflake-2.1.1.tar.gz", hash = "sha256:75524b48d42d6537041d91f17573b8a98cb645642f9f05c7fcc68de10b1cade3"},
+]
+black = [
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2"},
+    {file = "black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c"},
+    {file = "black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d"},
+    {file = "black-23.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70"},
+    {file = "black-23.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326"},
+    {file = "black-23.3.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b"},
+    {file = "black-23.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2"},
+    {file = "black-23.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5"},
+    {file = "black-23.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961"},
+    {file = "black-23.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266"},
+    {file = "black-23.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab"},
+    {file = "black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
+    {file = "black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4"},
+    {file = "black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940"},
+]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
@@ -256,9 +485,17 @@ colorama = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+exceptiongroup = [
+    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
+    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
+]
 fastapi = [
     {file = "fastapi-0.92.0-py3-none-any.whl", hash = "sha256:ae7b97c778e2f2ec3fb3cb4fb14162129411d99907fb71920f6d69a524340ebf"},
     {file = "fastapi-0.92.0.tar.gz", hash = "sha256:023a0f5bd2c8b2609014d3bba1e14a1d7df96c6abea0a73070621c9862b9a4de"},
+]
+flake8 = [
+    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
+    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
 ]
 greenlet = [
     {file = "greenlet-2.0.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:bdfea8c661e80d3c1c99ad7c3ff74e6e87184895bbaca6ee8cc61209f8b9b85d"},
@@ -330,6 +567,14 @@ idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
+iniconfig = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+isort = [
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
+]
 Mako = [
     {file = "Mako-1.2.4-py3-none-any.whl", hash = "sha256:c97c79c018b9165ac9922ae4f32da095ffd3c4e6872b45eded42926deea46818"},
     {file = "Mako-1.2.4.tar.gz", hash = "sha256:d60a3903dc3bb01a18ad6a89cdbe2e4eadc69c0bc8ef1e3773ba53d44c3f7a34"},
@@ -386,6 +631,58 @@ MarkupSafe = [
     {file = "MarkupSafe-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:0576fe974b40a400449768941d5d0858cc624e3249dfd1e0c33674e5c7ca7aed"},
     {file = "MarkupSafe-2.1.2.tar.gz", hash = "sha256:abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d"},
 ]
+mccabe = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+mypy = [
+    {file = "mypy-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eb485cea53f4f5284e5baf92902cd0088b24984f4209e25981cc359d64448d"},
+    {file = "mypy-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4c99c3ecf223cf2952638da9cd82793d8f3c0c5fa8b6ae2b2d9ed1e1ff51ba85"},
+    {file = "mypy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:550a8b3a19bb6589679a7c3c31f64312e7ff482a816c96e0cecec9ad3a7564dd"},
+    {file = "mypy-1.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cbc07246253b9e3d7d74c9ff948cd0fd7a71afcc2b77c7f0a59c26e9395cb152"},
+    {file = "mypy-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:a22435632710a4fcf8acf86cbd0d69f68ac389a3892cb23fbad176d1cddaf228"},
+    {file = "mypy-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6e33bb8b2613614a33dff70565f4c803f889ebd2f859466e42b46e1df76018dd"},
+    {file = "mypy-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7d23370d2a6b7a71dc65d1266f9a34e4cde9e8e21511322415db4b26f46f6b8c"},
+    {file = "mypy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:658fe7b674769a0770d4b26cb4d6f005e88a442fe82446f020be8e5f5efb2fae"},
+    {file = "mypy-1.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d29e324cdda61daaec2336c42512e59c7c375340bd202efa1fe0f7b8f8ca"},
+    {file = "mypy-1.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:d0b6c62206e04061e27009481cb0ec966f7d6172b5b936f3ead3d74f29fe3dcf"},
+    {file = "mypy-1.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:76ec771e2342f1b558c36d49900dfe81d140361dd0d2df6cd71b3db1be155409"},
+    {file = "mypy-1.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebc95f8386314272bbc817026f8ce8f4f0d2ef7ae44f947c4664efac9adec929"},
+    {file = "mypy-1.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:faff86aa10c1aa4a10e1a301de160f3d8fc8703b88c7e98de46b531ff1276a9a"},
+    {file = "mypy-1.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:8c5979d0deb27e0f4479bee18ea0f83732a893e81b78e62e2dda3e7e518c92ee"},
+    {file = "mypy-1.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c5d2cc54175bab47011b09688b418db71403aefad07cbcd62d44010543fc143f"},
+    {file = "mypy-1.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:87df44954c31d86df96c8bd6e80dfcd773473e877ac6176a8e29898bfb3501cb"},
+    {file = "mypy-1.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:473117e310febe632ddf10e745a355714e771ffe534f06db40702775056614c4"},
+    {file = "mypy-1.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:74bc9b6e0e79808bf8678d7678b2ae3736ea72d56eede3820bd3849823e7f305"},
+    {file = "mypy-1.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:44797d031a41516fcf5cbfa652265bb994e53e51994c1bd649ffcd0c3a7eccbf"},
+    {file = "mypy-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ddae0f39ca146972ff6bb4399f3b2943884a774b8771ea0a8f50e971f5ea5ba8"},
+    {file = "mypy-1.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1c4c42c60a8103ead4c1c060ac3cdd3ff01e18fddce6f1016e08939647a0e703"},
+    {file = "mypy-1.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e86c2c6852f62f8f2b24cb7a613ebe8e0c7dc1402c61d36a609174f63e0ff017"},
+    {file = "mypy-1.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f9dca1e257d4cc129517779226753dbefb4f2266c4eaad610fc15c6a7e14283e"},
+    {file = "mypy-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:95d8d31a7713510685b05fbb18d6ac287a56c8f6554d88c19e73f724a445448a"},
+    {file = "mypy-1.3.0-py3-none-any.whl", hash = "sha256:a8763e72d5d9574d45ce5881962bc8e9046bf7b375b0abf031f3e6811732a897"},
+    {file = "mypy-1.3.0.tar.gz", hash = "sha256:e1f4d16e296f5135624b34e8fb741eb0eadedca90862405b1f1fde2040b9bd11"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+packaging = [
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
+]
+pathspec = [
+    {file = "pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
+    {file = "pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
+]
+platformdirs = [
+    {file = "platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
+    {file = "platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
 psycopg2 = [
     {file = "psycopg2-2.9.6-cp310-cp310-win32.whl", hash = "sha256:f7a7a5ee78ba7dc74265ba69e010ae89dae635eea0e97b055fb641a01a31d2b1"},
     {file = "psycopg2-2.9.6-cp310-cp310-win_amd64.whl", hash = "sha256:f75001a1cbbe523e00b0ef896a5a1ada2da93ccd752b7636db5a99bc57c44494"},
@@ -400,6 +697,10 @@ psycopg2 = [
     {file = "psycopg2-2.9.6-cp39-cp39-win32.whl", hash = "sha256:1861a53a6a0fd248e42ea37c957d36950da00266378746588eab4f4b5649e95f"},
     {file = "psycopg2-2.9.6-cp39-cp39-win_amd64.whl", hash = "sha256:ded2faa2e6dfb430af7713d87ab4abbfc764d8d7fb73eafe96a24155f906ebf5"},
     {file = "psycopg2-2.9.6.tar.gz", hash = "sha256:f15158418fd826831b28585e2ab48ed8df2d0d98f502a2b4fe619e7d5ca29011"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
+    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
 ]
 pydantic = [
     {file = "pydantic-1.10.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e79e999e539872e903767c417c897e729e015872040e56b96e67968c3b918b2d"},
@@ -438,6 +739,14 @@ pydantic = [
     {file = "pydantic-1.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:d71e69699498b020ea198468e2480a2f1e7433e32a3a99760058c6520e2bea7e"},
     {file = "pydantic-1.10.7-py3-none-any.whl", hash = "sha256:0cd181f1d0b1d00e2b705f1bf1ac7799a2d938cce3376b8007df62b29be3c2c6"},
     {file = "pydantic-1.10.7.tar.gz", hash = "sha256:cfc83c0678b6ba51b0532bea66860617c4cd4251ecf76e9846fa5a9f3454e97e"},
+]
+pyflakes = [
+    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
+    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
+]
+pytest = [
+    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
+    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
 ]
 python-dotenv = [
     {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
@@ -493,6 +802,10 @@ SQLAlchemy = [
 starlette = [
     {file = "starlette-0.25.0-py3-none-any.whl", hash = "sha256:774f1df1983fd594b9b6fb3ded39c2aa1979d10ac45caac0f4255cbe2acb8628"},
     {file = "starlette-0.25.0.tar.gz", hash = "sha256:854c71e73736c429c2bdb07801f2c76c9cba497e7c3cf4988fde5e95fe4cdb3c"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,33 @@ python-dotenv = "^1.0.0"
 alembic = "^1.10.4"
 
 
+[tool.poetry.group.dev.dependencies]
+flake8 = "^6.0.0"
+black = "^23.3.0"
+mypy = "^1.3.0"
+isort = "^5.12.0"
+pytest = "^7.3.1"
+autoflake = "^2.1.1"
+
+[tool.isort]
+profile = "black"
+
+[tool.black]
+target-version = ['py37', 'py38']
+include = '''
+(
+    ^/app/
+)
+'''
+exclude = '''
+(
+    __pycache__
+    | .pytest_cache
+    | .gitignore  
+    | ^.*.mako
+)
+'''
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+set -x
+
+autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place app --exclude=__init__.py
+black app
+isort app

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+mypy app
+black app --check
+isort --check-only app
+flake8 app

--- a/tests/create-testing-database.sql
+++ b/tests/create-testing-database.sql
@@ -1,2 +1,0 @@
-SELECT 'CREATE DATABASE testing'
-    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'testing')\gexec


### PR DESCRIPTION
## Description

- Adds flake8, black, isort and autoflake together with their dependencies.
- Alters dockerfile and docker-compose.
- Adjusts relative imports.

## Reason for change

- Maintain consistency in data formatting for readability and standardization.

## Checklist

- [ ] I have added/updated tests for this change (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] This PR doesn't contain any unrelated changes.

## References

- N/A